### PR TITLE
Update node-exporter-daemonset.yml

### DIFF
--- a/node-exporter-daemonset.yml
+++ b/node-exporter-daemonset.yml
@@ -6,6 +6,9 @@ metadata:
   labels:
     name: node-exporter
 spec:
+  selector:
+    matchLabels:  
+      name: node-exporter
   template:
     metadata:
       labels:


### PR DESCRIPTION
add `selector.matchLabels.name: node-exporter` in manifest as per k8s 1.18+ requirement. Tested it 